### PR TITLE
Fix scope string not working

### DIFF
--- a/instagram_client.js
+++ b/instagram_client.js
@@ -15,6 +15,9 @@ Instagram.requestCredential = function (options, credentialRequestCompleteCallba
   var credentialToken = Random.secret();
   var loginStyle = OAuth._loginStyle('instagram', config, options);
   var scope = (config.scope) || ['basic', 'likes', 'relationships', 'comments'];
+  if (typeof scope === 'string') {
+    scope = [scope];
+  }
   var flatScope = _.map(scope, encodeURIComponent).join('+');
 
   var loginUrl =


### PR DESCRIPTION
If we use

```
 ServiceConfiguration.configurations.insert({
    service: 'instagram',
    scope: 'basic',
    clientId: '<your-client-id>',
    secret: '<your-client-secret>'
  });
```

We get this error because `map` is call on a string.

![capture d ecran 2016-06-15 a 14 51 20](https://cloud.githubusercontent.com/assets/5749437/16081555/4f2d828c-330e-11e6-87d9-57d36158060a.png)
